### PR TITLE
Allow for a period in the GUID of the External ID

### DIFF
--- a/pkg/apis/servicecatalog/validation/serviceclass.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass.go
@@ -30,7 +30,7 @@ import (
 // validateServiceClassName is the validation function for ServiceClass names.
 var validateServiceClassName = apivalidation.NameIsDNSSubdomain
 
-const guidFmt string = "[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?"
+const guidFmt string = "[a-zA-Z0-9]([-a-zA-Z0-9.]*[a-zA-Z0-9])?"
 const guidMaxLength int = 63
 
 // guidRegexp is a loosened validation for

--- a/pkg/apis/servicecatalog/validation/serviceclass_test.go
+++ b/pkg/apis/servicecatalog/validation/serviceclass_test.go
@@ -73,6 +73,15 @@ func TestValidateServiceClass(t *testing.T) {
 			valid: true,
 		},
 		{
+			name: "valid serviceClass - period in GUID",
+			serviceClass: func() *servicecatalog.ServiceClass {
+				s := validServiceClass()
+				s.ExternalID = "4315f5e1-0139-4ecf-9706-9df0aff33e5a.plan-name"
+				return s
+			}(),
+			valid: true,
+		},
+		{
 			name: "invalid serviceClass - has namespace",
 			serviceClass: func() *servicecatalog.ServiceClass {
 				s := validServiceClass()


### PR DESCRIPTION
The hashicorp/cf-vault-service-broker appends the plan name onto the GUID for the External ID using a period as the separator. The [Pivotal docs](http://docs.pivotal.io/pivotalcf/1-8/services/api.html#PObject) do not specify an exact format and simply state `using a GUID is recommended`.

This change relaxes the regEx check to allow for periods in the External ID so this and other brokers that use this style will work for k8s. 